### PR TITLE
Richer judgmental apparatus

### DIFF
--- a/src/dynamics/dynamics.sml
+++ b/src/dynamics/dynamics.sml
@@ -105,7 +105,7 @@ struct
       case theta $ args of
            CUST (opid, params, arity) $ args =>
              stepCust sign (opid, arity) cl
-         | LVL_OP (LBASE _) $ _ => FINAL
+         | LVL_OP LBASE $ _ => FINAL
          | LVL_OP LSUCC $ [_ \ l] =>
              step sign (l <: env) <#> (fn l' <: env =>
                check (metactx l') (LVL_OP LSUCC $ [([],[]) \ l'], LVL) <: env)

--- a/src/nominal-lcf/elaborator.fun
+++ b/src/nominal-lcf/elaborator.fun
@@ -57,7 +57,7 @@ struct
       val x = Abt.Metavariable.named "?"
       val psi = Tele.snoc Tele.empty (x, jdg)
     in
-      print (DebugShowAbt.toString m ^ "\n");
+      print (ShowAbt.toString m ^ "\n");
       (psi, fn rho => Tele.lookup rho x)
     end
 

--- a/src/nominal-lcf/elaborator.fun
+++ b/src/nominal-lcf/elaborator.fun
@@ -105,6 +105,8 @@ struct
              R.EvalGoal sign
          | LCF (WITNESS tau) $ [_ \ m] =>
              R.Witness m
+         | LCF REC $ [(_, [x]) \ t] =>
+             Rec (fn T => elaborate sign (VarCtx.insert rho x T) t)
          | `x => VarCtx.lookup rho x
          | _ => raise Fail ("Expected tactic, got: " ^ DebugShowAbt.toString t ^ " which evaluated to " ^ DebugShowAbt.toString t')
     end

--- a/src/nominal-lcf/elaborator.fun
+++ b/src/nominal-lcf/elaborator.fun
@@ -105,6 +105,8 @@ struct
              R.EvalGoal sign
          | LCF (WITNESS tau) $ [_ \ m] =>
              R.Witness m
+         | LCF AUTO $ [] =>
+             R.AutoStep sign
          | LCF REC $ [(_, [x]) \ t] =>
              Rec (fn T => elaborate sign (VarCtx.insert rho x T) t)
          | `x => VarCtx.lookup rho x

--- a/src/refiner.cm
+++ b/src/refiner.cm
@@ -16,6 +16,8 @@ is
   refiner/refiner_kit.sml
   refiner/rules/cequiv.sig
   refiner/rules/cequiv.sml
+  refiner/rules/type.sig
+  refiner/rules/type.sml
   refiner/rules/univ.sig
   refiner/rules/univ.sml
   refiner/rules/base.sig

--- a/src/refiner.mlb
+++ b/src/refiner.mlb
@@ -11,6 +11,8 @@ local
   refiner/refiner_kit.sml
   refiner/rules/cequiv.sig
   refiner/rules/cequiv.sml
+  refiner/rules/type.sig
+  refiner/rules/type.sml
   refiner/rules/univ.sig
   refiner/rules/univ.sml
   refiner/rules/base.sig

--- a/src/refiner/judgment.sml
+++ b/src/refiner/judgment.sml
@@ -12,7 +12,8 @@ struct
     "{" ^ Sequent.toString s ^ "}"
 
   infix >>
-  fun evidenceValence (_ >> (_, tau)) = (([],[]), tau)
+  fun evidenceValence (_ >> TRUE (_, tau)) = (([],[]), tau)
+    | evidenceValence (_ >> TYPE _) = (([],[]), SortData.LVL)
 
   fun evidenceToString e =
     let
@@ -23,13 +24,17 @@ struct
     end
 
   open Sequent infix >>
-  fun substJudgment (x, e) (H >> (P, tau)) =
+  fun substConcl (x, e) =
+    fn TRUE (P, tau) => TRUE (metasubst (e,x) P, tau)
+     | TYPE (P, tau) => TYPE (metasubst (e,x) P, tau)
+
+  fun substJudgment (x, e) (H >> concl) =
     let
       val H' =
         {metactx = #metactx H,
          symctx = #symctx H,
          hypctx = SymbolTelescope.map (#hypctx H) (fn (Q, tau) => (metasubst (e, x) Q, tau))}
     in
-      H' >> (metasubst (e, x) P, tau)
+      H' >> substConcl (x, e) concl
     end
 end

--- a/src/refiner/judgment.sml
+++ b/src/refiner/judgment.sml
@@ -9,7 +9,7 @@ struct
   type evidence = abs
 
   fun judgmentToString s =
-    "{" ^ Sequent.toString s ^ "}"
+    Sequent.toString s
 
   infix >>
   fun evidenceValence (_ >> TRUE (_, tau)) = (([],[]), tau)
@@ -20,7 +20,7 @@ struct
       infix \
       val _ \ m = outb e
     in
-      DebugShowAbt.toString m
+      ShowAbt.toString m
     end
 
   open Sequent infix >>

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -16,6 +16,8 @@ sig
 
   type ntactic = name_store -> Tacticals.Lcf.tactic
 
+  val stateToString : Tacticals.Lcf.judgment Tacticals.Lcf.state -> string
+
   val Elim
     : symbol      (* target *)
     -> ntactic

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -60,6 +60,10 @@ sig
     : abt
     -> ntactic
 
+  val AutoStep
+    : AbtSignature.sign
+    -> ntactic
+
 end
 
 

--- a/src/refiner/refiner.sml
+++ b/src/refiner/refiner.sml
@@ -114,9 +114,16 @@ struct
 
     fun ProveIsType alpha =
       fn jdg as H >> TYPE (P, tau) =>
-          Tacticals.THENF
-            (TypeRules.Intro alpha, 0, Witness (inferTypeLevel H P) alpha)
-            jdg
+           Tacticals.THENF
+             (TypeRules.Intro alpha, 0, Witness (inferTypeLevel H P) alpha)
+             jdg
+       | _ => raise Match
+
+    fun TrivIntro alpha =
+      fn jdg as H >> TRUE (P, _) =>
+           (case out P of
+                CTT (BASE SortData.TRIV) $ _ => Witness makeAx alpha jdg
+              | _ => raise Match)
        | _ => raise Match
   end
 
@@ -130,7 +137,8 @@ struct
           ProveIsType alpha
             ORELSE Intro NONE alpha
             ORELSE Eq NONE alpha
-            ORELSE EvalGoal sign alpha
             ORELSE CStep sign 0 alpha
+            ORELSE TrivIntro alpha
+            ORELSE EvalGoal sign alpha
   end
 end

--- a/src/refiner/refiner.sml
+++ b/src/refiner/refiner.sml
@@ -109,6 +109,13 @@ struct
           | CTT (CAPPROX _) $ _ => lbase
           | CTT (EQ _) $ _ => lbase
           | CTT (SQUASH _) $ [_ \ a] => inferTypeLevel H a (* we may be able to make this just [lbase] *)
+          | `x =>
+              let
+                val (univ, _) = Ctx.lookup (#hypctx H) x
+                val (_, i) = destUniv univ
+              in
+                i
+              end
           | _ => raise Fail "Level inference heuristic failed"
     end
 

--- a/src/refiner/refiner.sml
+++ b/src/refiner/refiner.sml
@@ -16,6 +16,7 @@ struct
     fun Intro r alpha =
       SquashRules.Intro alpha
         ORELSE SpeciesRules.Intro alpha
+        ORELSE TypeRules.Intro alpha
 
     fun Eq r alpha (jdg as H >> TRUE (P, _)) =
       (case out P of

--- a/src/refiner/refiner_kit.sml
+++ b/src/refiner/refiner_kit.sml
@@ -105,10 +105,10 @@ struct
          EXP)
 
     fun makeEqSequent H args =
-      H >> (makeEq (#metactx H) args, TRIV)
+      H >> TRUE (makeEq (#metactx H) args, TRIV)
 
     fun makeMemberSequent H args =
-      H >> (makeMember (#metactx H) args, TRIV)
+      H >> TRUE (makeMember (#metactx H) args, TRIV)
 
     fun makeLevelSequent (H : Sequent.context) =
       let
@@ -117,7 +117,7 @@ struct
            symctx = #symctx H,
            hypctx = Ctx.empty}
       in
-        H' >> (check' (CTT (BASE LVL) $ [], EXP), LVL)
+        H' >> TRUE (check' (CTT (BASE LVL) $ [], EXP), LVL)
       end
 
 

--- a/src/refiner/refiner_kit.sml
+++ b/src/refiner/refiner_kit.sml
@@ -120,8 +120,8 @@ struct
         H' >> TRUE (check' (CTT (BASE LVL) $ [], EXP), LVL)
       end
 
-
     val makeAx = check' (CTT AX $ [], TRIV)
   end
 
+  fun @> (t,g) = T.snoc t g
 end

--- a/src/refiner/rules/base.sml
+++ b/src/refiner/rules/base.sml
@@ -11,7 +11,7 @@ struct
              @@ "Expected Base but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq alpha (H >> (P, _)) =
+  fun TypeEq alpha (H >> TRUE (P, _)) =
     let
       val (tau, m,n,a) = destEq P
       val (tau1, tau2) = (destBase m, destBase n)
@@ -20,8 +20,9 @@ struct
       (T.empty, fn rho =>
         abtToAbs (check' (CTT AX $ [], TRIV)))
     end
+    | TypeEq _ _ = raise Match
 
-  fun MemberEq alpha (H >> (P, _)) =
+  fun MemberEq alpha (H >> TRUE (P, _)) =
     let
       val (tau, m,n,a) = destEq P
 
@@ -35,18 +36,19 @@ struct
               val base = check' (CTT (BASE tau) $ [], EXP)
               val goal = check' (CTT (MEMBER tau) $ [([],[]) \ xtm, ([],[]) \ base], EXP)
             in
-              T.snoc tl (meta, H >> (goal, EXP))
+              T.snoc tl (meta, H >> TRUE (goal, EXP))
             end)
           T.empty
           (varctx m)
       val mainGoal = check (#metactx H) (CTT (CEQUIV tau) $ [([],[]) \ m, ([],[]) \ n], EXP)
-      val subgoals' = T.snoc subgoals (newMeta "", H >> (mainGoal, EXP))
+      val subgoals' = T.snoc subgoals (newMeta "", H >> TRUE (mainGoal, EXP))
     in
       (subgoals', fn rho =>
         abtToAbs (check' (CTT AX $ [], TRIV)))
     end
+    | MemberEq _ _ = raise Match
 
-  fun Elim h alpha (H >> (P, sigma)) =
+  fun Elim h alpha (H >> TRUE (P, sigma)) =
     let
       val (base, tau) = Ctx.lookup (#hypctx H) h
       val _ = destBase base
@@ -63,10 +65,11 @@ struct
          hypctx = ctx'}
       val goal =
         (newMeta "",
-         H' >> (P, sigma))
+         H' >> TRUE (P, sigma))
       val psi = T.snoc T.empty goal
     in
       (psi, fn rho =>
         mapAbs (subst (makeAx, z)) (T.lookup rho (#1 goal)))
     end
+    | Elim _ _ _ = raise Match
 end

--- a/src/refiner/rules/base.sml
+++ b/src/refiner/rules/base.sml
@@ -44,7 +44,7 @@ struct
       val subgoals' = T.snoc subgoals (newMeta "", H >> TRUE (mainGoal, EXP))
     in
       (subgoals', fn rho =>
-        abtToAbs (check' (CTT AX $ [], TRIV)))
+        abtToAbs makeAx)
     end
     | MemberEq _ _ = raise Match
 

--- a/src/refiner/rules/cequiv.sml
+++ b/src/refiner/rules/cequiv.sml
@@ -3,7 +3,7 @@ struct
   open RefinerKit OperatorData CttOperatorData SortData
   infix >> $ \
 
-  fun TypeEq _ (H >> (P, _)) =
+  fun TypeEq _ (H >> TRUE (P, _)) =
     let
       val (_, ceq1, ceq2, univ) = destEq P
       val i = destUniv univ
@@ -12,28 +12,30 @@ struct
       val () = if tau1 = tau2 then () else raise Fail "CEquiv.TypeEq: sort mismatch"
       val goal1 =
         (newMeta "",
-         H >> (makeCEquiv (#metactx H) (m1, m2), TRIV))
+         H >> TRUE (makeCEquiv (#metactx H) (m1, m2), TRIV))
       val goal2 =
         (newMeta "",
-         H >> (makeCEquiv (#metactx H) (n1, n2), TRIV))
+         H >> TRUE (makeCEquiv (#metactx H) (n1, n2), TRIV))
       val psi = T.snoc (T.snoc T.empty goal1) goal2
     in
       (psi, fn rho =>
         abtToAbs makeAx)
     end
+    | TypeEq _ _ = raise Match
 
-  fun CSym _ (H >> (P, _)) =
+  fun CSym _ (H >> TRUE (P, _)) =
     let
       val (tau, m, n) = destCEquiv P
       val x = newMeta ""
       val subgoal = makeCEquiv (#metactx H) (n,m)
-      val psi = T.snoc T.empty (x, H >> (subgoal, TRIV))
+      val psi = T.snoc T.empty (x, H >> TRUE (subgoal, TRIV))
     in
       (psi, fn rho =>
         abtToAbs makeAx)
     end
+    | CSym _ _ = raise Match
 
-  fun CStep sign i _ (H >> (P, _)) =
+  fun CStep sign i _ (H >> TRUE (P, _)) =
     let
       val (tau, m, n) = destCEquiv P
       val m' = DynamicsUtil.stepn sign i m
@@ -45,14 +47,15 @@ struct
          let
            val x = newMeta ""
            val subgoal = makeCEquiv (#metactx H) (m', n)
-           val psi = T.snoc T.empty (x, H >> (subgoal, TRIV))
+           val psi = T.snoc T.empty (x, H >> TRUE (subgoal, TRIV))
          in
            (psi, fn rho =>
              abtToAbs makeAx)
          end)
     end
+    | CStep _ _ _ _ = raise Match
 
-  fun CEval sign _ (H >> (P, _)) =
+  fun CEval sign _ (H >> TRUE (P, _)) =
     let
       val (tau, m, n) = destCEquiv P
       val m' = DynamicsUtil.evalOpen sign m
@@ -64,10 +67,11 @@ struct
          let
            val x = newMeta ""
            val subgoal = makeCEquiv (#metactx H) (m', n)
-           val psi = T.snoc T.empty (x, H >> (subgoal, TRIV))
+           val psi = T.snoc T.empty (x, H >> TRUE (subgoal, TRIV))
          in
            (psi, fn rho =>
              abtToAbs makeAx)
          end)
     end
+    | CEval _ _ _ = raise Match
 end

--- a/src/refiner/rules/species.sml
+++ b/src/refiner/rules/species.sml
@@ -84,21 +84,28 @@ struct
         (newMeta "",
          H >> TRUE (a, tau1))
 
+      val H' =
+        {metactx = MetaCtx.insert (#metactx H) (#1 mainGoal) (([],[]), tau1),
+         symctx = #symctx H,
+         hypctx = #hypctx H}
+
+      val mainHole = check (#metactx H') (#1 mainGoal $# ([],[]), tau1)
+      val pred = subst (mainHole, x) b
       val predGoal =
         (newMeta "",
-         H >> TRUE (makeSquash (#metactx H) tau1 a, TRIV))
+         H >> TRUE (makeSquash (#metactx H) tau2 pred, TRIV))
 
       val z = alpha 0
       val bz = subst (check' (`z, tau1), x) b
 
-      val H' =
-        {metactx = #metactx H,
-         symctx = #symctx H,
-         hypctx = Ctx.snoc (#hypctx H) (z, (a, tau1))}
+      val H'' =
+        {metactx = #metactx H',
+         symctx = #symctx H',
+         hypctx = Ctx.snoc (#hypctx H') (z, (a, tau1))}
 
       val tyfunGoal =
         (newMeta "",
-         H' >> TYPE (bz, tau2))
+         H'' >> TYPE (bz, tau2))
 
       val psi = T.empty @> mainGoal @> predGoal @> tyfunGoal
     in

--- a/src/refiner/rules/species.sml
+++ b/src/refiner/rules/species.sml
@@ -14,7 +14,7 @@ struct
              @@ "Expected Species but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq alpha (H >> (P, _)) =
+  fun TypeEq alpha (H >> TRUE (P, _)) =
     let
       val (tau,s1,s2,univ) = destEq P
       val (_, _, a1, x1, b1) = destSpecies s1
@@ -45,8 +45,9 @@ struct
       (psi, fn rho =>
         abtToAbs makeAx)
     end
+    | TypeEq _ _ = raise Match
 
-  fun MemberEq alpha (H >> (P, _)) =
+  fun MemberEq alpha (H >> TRUE (P, _)) =
     let
       val (_, m1, m2, sp) = destEq P
       val (tau1, tau2, a, x, b) = destSpecies sp
@@ -57,7 +58,7 @@ struct
       val bm = subst (m1, x) b
       val squashGoal =
         (newMeta "",
-         H >> (makeSquash (#metactx H) tau2 bm, TRIV))
+         H >> TRUE (makeSquash (#metactx H) tau2 bm, TRIV))
 
       val z = alpha 0
       val bz = subst (check' (`z, tau1), x) b
@@ -90,18 +91,19 @@ struct
       (psi, fn rho =>
         abtToAbs makeAx)
     end
+    | MemberEq _ _ = raise Match
 
-  fun Intro alpha (H >> (P, _)) =
+  fun Intro alpha (H >> TRUE (P, _)) =
     let
       val (tau1, tau2, a, x, b) = destSpecies P
 
       val mainGoal =
         (newMeta "",
-         H >> (a, tau1))
+         H >> TRUE (a, tau1))
 
       val predGoal =
         (newMeta "",
-         H >> (makeSquash (#metactx H) tau1 a, TRIV))
+         H >> TRUE (makeSquash (#metactx H) tau1 a, TRIV))
 
       val lvlGoal = (newMeta "", makeLevelSequent H)
 
@@ -134,4 +136,5 @@ struct
       (psi, fn rho =>
         T.lookup rho (#1 mainGoal))
     end
+    | Intro _ _ = raise Match
 end

--- a/src/refiner/rules/species.sml
+++ b/src/refiner/rules/species.sml
@@ -1,10 +1,7 @@
 structure SpeciesRules : SPECIES_RULES =
 struct
   open RefinerKit OperatorData CttOperatorData SortData
-  infix @@ >> $ $# \
-
-  fun @> (t,g) = T.snoc t g
-  infix @>
+  infix @@ >> $ $# \ @>
 
   fun destSpecies m =
     case out m of
@@ -63,30 +60,16 @@ struct
       val z = alpha 0
       val bz = subst (check' (`z, tau1), x) b
 
-      val lvlGoal = (newMeta "", makeLevelSequent H)
-
       val H' =
-        {metactx = MetaCtx.insert (#metactx H) (#1 lvlGoal) (([],[]), LVL),
+        {metactx = #metactx H,
          symctx = #symctx H,
          hypctx = Ctx.snoc (#hypctx H) (z, (a, tau1))}
 
-      val lvlHole =
-        check
-          (#metactx H')
-          (#1 lvlGoal $# ([], []),
-           LVL)
-
-      val univ =
-        check
-          (#metactx H')
-          (CTT (UNIV tau2) $ [([],[]) \ lvlHole],
-           EXP)
-
       val tyfunGoal =
         (newMeta "",
-         makeMemberSequent H' (bz, univ))
+         H' >> TYPE (bz, tau2))
 
-      val psi = T.empty @> tyGoal @> squashGoal @> lvlGoal @> tyfunGoal
+      val psi = T.empty @> tyGoal @> squashGoal @> tyfunGoal
     in
       (psi, fn rho =>
         abtToAbs makeAx)
@@ -105,33 +88,19 @@ struct
         (newMeta "",
          H >> TRUE (makeSquash (#metactx H) tau1 a, TRIV))
 
-      val lvlGoal = (newMeta "", makeLevelSequent H)
-
       val z = alpha 0
       val bz = subst (check' (`z, tau1), x) b
 
       val H' =
-        {metactx = MetaCtx.insert (#metactx H) (#1 lvlGoal) (([],[]), LVL),
+        {metactx = #metactx H,
          symctx = #symctx H,
          hypctx = Ctx.snoc (#hypctx H) (z, (a, tau1))}
 
-      val lvlHole =
-        check
-          (#metactx H')
-          (#1 lvlGoal $# ([], []),
-           LVL)
-
-      val univ =
-        check
-          (#metactx H')
-          (CTT (UNIV tau2) $ [([],[]) \ lvlHole],
-           EXP)
-
       val tyfunGoal =
         (newMeta "",
-         makeMemberSequent H' (bz, univ))
+         H' >> TYPE (bz, tau2))
 
-      val psi = T.empty @> mainGoal @> predGoal @> lvlGoal @> tyfunGoal
+      val psi = T.empty @> mainGoal @> predGoal @> tyfunGoal
     in
       (psi, fn rho =>
         T.lookup rho (#1 mainGoal))

--- a/src/refiner/rules/squash.sml
+++ b/src/refiner/rules/squash.sml
@@ -11,7 +11,7 @@ struct
              @@ "Expected Squash but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq _ (H >> (P, _)) =
+  fun TypeEq _ (H >> TRUE (P, _)) =
     let
       val (tau,a,b,univ) = destEq P
       val (_, a') = destSquash a
@@ -21,22 +21,24 @@ struct
         check
           (#metactx H)
           (CTT (EQ tau) $ [([],[]) \ a', ([],[]) \ b', ([],[]) \ univ], EXP)
-      val psi = T.snoc T.empty (newMeta "", H >> (goal, EXP))
+      val psi = T.snoc T.empty (newMeta "", H >> TRUE (goal, EXP))
     in
       (psi, fn rho =>
-        abtToAbs (check' (CTT AX $ [], TRIV)))
+        abtToAbs makeAx)
     end
+    | TypeEq _ _ = raise Match
 
-  fun Intro _ (H >> (P, _)) =
+  fun Intro _ (H >> TRUE (P, _)) =
     let
       val (tau, Q) = destSquash P
-      val psi = T.snoc T.empty (newMeta "", H >> (Q, tau))
+      val psi = T.snoc T.empty (newMeta "", H >> TRUE (Q, tau))
     in
       (psi, fn rho =>
-        abtToAbs (check' (CTT AX $ [], TRIV)))
+        abtToAbs makeAx)
     end
+    | Intro _ _ = raise Match
 
-  fun Unhide h _ (H >> (P, tau)) =
+  fun Unhide h _ (H >> TRUE (P, tau)) =
     let
       val _ = destEq P
       val (Q, sigma) = Ctx.lookup (#hypctx H) h
@@ -47,10 +49,11 @@ struct
          hypctx = Ctx.modify (#hypctx H) (h, fn _ => (Q', tau'))}
 
       val x = newMeta ""
-      val psi = T.snoc T.empty (x, H' >> (P, tau))
+      val psi = T.snoc T.empty (x, H' >> TRUE (P, tau))
     in
       (psi, fn rho =>
         T.lookup rho x)
     end
+    | Unhide _ _ _ = raise Match
 
 end

--- a/src/refiner/rules/type.sig
+++ b/src/refiner/rules/type.sig
@@ -1,0 +1,5 @@
+(* rules for the [H >> P type] judgment, which synthesizes a level. *)
+signature TYPE_RULES =
+sig
+  val Intro : RefinerKit.ntactic
+end

--- a/src/refiner/rules/type.sml
+++ b/src/refiner/rules/type.sml
@@ -1,0 +1,36 @@
+structure TypeRules : TYPE_RULES =
+struct
+  open RefinerKit OperatorData CttOperatorData SortData
+  infix >> $ $# \ @>
+
+  fun Intro _ (H >> TYPE (P, tau)) =
+    let
+      val lvlGoal = (newMeta "", makeLevelSequent H)
+      val H' =
+        {metactx = MetaCtx.insert (#metactx H) (#1 lvlGoal) (([],[]), LVL),
+         symctx = #symctx H,
+         hypctx = #hypctx H}
+
+      val lvlHole =
+        check
+          (#metactx H')
+          (#1 lvlGoal $# ([], []),
+           LVL)
+
+      val univ =
+        check
+          (#metactx H')
+          (CTT (UNIV tau) $ [([],[]) \ lvlHole],
+           EXP)
+
+      val memGoal =
+        (newMeta "",
+         makeMemberSequent H' (P, univ))
+
+      val psi = T.empty @> lvlGoal @> memGoal
+    in
+      (psi, fn rho =>
+        T.lookup rho (#1 lvlGoal))
+    end
+    | Intro _ _ = raise Match
+end

--- a/src/refiner/rules/univ.sml
+++ b/src/refiner/rules/univ.sml
@@ -72,7 +72,7 @@ struct
               ^ " < "
               ^ DebugShowAbt.toString j
 
-  fun Eq alpha (H >> (P, _)) =
+  fun Eq alpha (H >> TRUE (P, _)) =
     let
       val (tau, m, n, a) = destEq P
       val () = if tau = EXP then () else raise Fail "Expected exp"
@@ -82,6 +82,7 @@ struct
       val () = assertLevelLt (i, k)
     in
       (T.empty, fn rho =>
-        abtToAbs (check' (CTT AX $ [], TRIV)))
+        abtToAbs makeAx)
     end
+    | Eq _ _ = raise Match
 end

--- a/src/signature-elab/refine_elab.sml
+++ b/src/signature-elab/refine_elab.sml
@@ -44,7 +44,7 @@ struct
                          {metactx = List.foldl (fn ((x,vl), psi) => MetaCtx.insert psi x vl) MetaCtx.empty arguments,
                           symctx = List.foldl (fn ((u,tau), upsilon) => SymCtx.insert upsilon u tau) SymCtx.empty parameters,
                           hypctx = SymbolTelescope.empty}
-                       val goal = context >> (prop, tau)
+                       val goal = context >> TRUE (prop, tau)
                        val st as (psi, vld) = E.elaborate' sign script alpha goal
                      in
                        case Ctx.ConsView.out psi of

--- a/src/signature-elab/refine_elab.sml
+++ b/src/signature-elab/refine_elab.sml
@@ -63,7 +63,7 @@ struct
                               end
                           | _ => raise Fail
                                    ("Incomplete proof:\n\n"
-                                      ^ E.Refiner.Tacticals.Lcf.stateToString st
+                                      ^ E.Refiner.stateToString st
                                       ^ "\n\n")
                      end
                  | _ => raise Fail "Expected either OP_SOME or OP_NONE")

--- a/src/signature/term_parser.sml
+++ b/src/signature/term_parser.sml
@@ -94,7 +94,7 @@ struct
       fn LVL =>
          let
            val parseBase =
-             symbol "lbase" >> brackets parseSymbol
+             symbol "lbase" >> squares parseSymbol
                wth (fn u =>
                  LVL_OP (LBASE u) $ [])
            val parseSucc =

--- a/src/signature/term_parser.sml
+++ b/src/signature/term_parser.sml
@@ -257,6 +257,10 @@ struct
              symbol "intro"
                return (LCF (INTRO {rule = NONE}) $ [])
 
+           val parseAuto =
+             symbol "auto"
+               return (LCF AUTO $ [])
+
            val parseUnhide =
              symbol "unhide"
                >> squares (parseSymbol && ((colon >> parseSort sign) || succeed EXP))
@@ -306,6 +310,7 @@ struct
                || parseElim
                || parseIntro
                || parseUnhide
+               || parseAuto
                || parseRec
                || parseRewriteGoal
                || parseEvalGoal

--- a/src/signature/term_parser.sml
+++ b/src/signature/term_parser.sml
@@ -94,9 +94,9 @@ struct
       fn LVL =>
          let
            val parseBase =
-             symbol "lbase" >> squares parseSymbol
+             symbol "lbase"
                wth (fn u =>
-                 LVL_OP (LBASE u) $ [])
+                 LVL_OP LBASE $ [])
            val parseSucc =
              symbol "lsuc" >> parens (f LVL)
                wth (fn l =>

--- a/src/syntax/level/operator.sml
+++ b/src/syntax/level/operator.sml
@@ -1,7 +1,7 @@
 structure LevelOperatorData =
 struct
   datatype 'i level_operator =
-      LBASE of 'i
+      LBASE
     | LSUCC
 end
 
@@ -13,20 +13,20 @@ struct
 
   type 'i t = 'i level_operator
 
-  fun arity (LBASE i) = ([], LVL)
+  fun arity LBASE = ([], LVL)
     | arity LSUCC = ([(([], []), LVL)], LVL)
 
-  fun support (LBASE i) = [(i, LVL)]
+  fun support LBASE = []
     | support LSUCC = []
 
-  fun map f (LBASE i) = LBASE (f i)
+  fun map f LBASE = LBASE
     | map f LSUCC = LSUCC
 
-  fun eq f (LBASE i, LBASE j) = f (i, j)
+  fun eq f (LBASE, LBASE) = true
     | eq f (LSUCC, LSUCC) = true
     | eq _ _ = false
 
-  fun toString f (LBASE i) = "lbase[" ^ f i ^ "]"
+  fun toString f LBASE = "lbase"
     | toString f LSUCC = "lsucc"
 
 end

--- a/src/syntax/nominal-lcf/operator.sml
+++ b/src/syntax/nominal-lcf/operator.sml
@@ -16,6 +16,7 @@ struct
     | INTRO of intro_params
     | EQ of eq_params
     | ELIM of 'i * Sort.t | HYP of 'i * Sort.t | UNHIDE of 'i * Sort.t
+    | AUTO
     | ID | FAIL | TRACE of Sort.t
     | CSTEP of int | CEVAL | CSYM
     | REWRITE_GOAL of Sort.t | EVAL_GOAL
@@ -65,6 +66,8 @@ struct
           [] ->> TAC
       | arity (UNHIDE _) =
           [] ->> TAC
+      | arity AUTO =
+          [] ->> TAC
       | arity ID =
           [] ->> TAC
       | arity FAIL =
@@ -107,6 +110,7 @@ struct
      | ELIM (target, tau) => ELIM (f target, tau)
      | HYP (target, tau) => HYP (f target, tau)
      | UNHIDE (target, tau) => UNHIDE (f target, tau)
+     | AUTO => AUTO
      | ID => ID
      | FAIL => FAIL
      | TRACE tau => TRACE tau
@@ -127,6 +131,7 @@ struct
      | (ELIM (u, sigma), ELIM (v, tau)) => f (u, v) andalso sigma = tau
      | (HYP (u, sigma), HYP (v, tau)) => f (u, v) andalso sigma = tau
      | (UNHIDE (u, sigma), UNHIDE (v, tau)) => f (u, v) andalso sigma = tau
+     | (AUTO, AUTO) => true
      | (ID, ID) => true
      | (FAIL, FAIL) => true
      | (TRACE tau1, TRACE tau2) => tau1 = tau2
@@ -150,6 +155,7 @@ struct
      | ELIM (target,tau) => "elim[" ^ f target ^ " : " ^ Sort.toString tau ^ "]"
      | HYP (target, tau) => "hyp[" ^ f target ^ " : " ^ Sort.toString tau ^ "]"
      | UNHIDE (target, tau) => "unhide[" ^ f target ^ " : " ^ Sort.toString tau ^ "]"
+     | AUTO => "auto"
      | ID => "id"
      | FAIL => "fail"
      | TRACE tau => "trace{" ^ Sort.toString tau ^ "}"

--- a/src/syntax/sequent.sig
+++ b/src/syntax/sequent.sig
@@ -4,7 +4,11 @@ sig
   type prop
   type sort
 
-  datatype sequent = >> of context * (prop * sort)
+  datatype concl =
+      TRUE of prop * sort
+    | TYPE of prop * sort
+
+  datatype sequent = >> of context * concl
 
   val toString : sequent -> string
 end

--- a/src/syntax/sequent.sml
+++ b/src/syntax/sequent.sml
@@ -13,14 +13,22 @@ struct
    * produced, and [P] is a type that refines [tau] which shall classify the
    * evidence. *)
 
+  datatype concl =
+      TRUE of prop * sort
+    | TYPE of prop * sort
+
   (* The meaning of the sequent with respect to its context of metavariables is
    * essentially the following: If the metavariables are replaced by closed abstractions
    * that respect computation, then the sequent is evident. *)
-  datatype sequent = >> of context * (prop * sort)
+  datatype sequent = >> of context * concl
   infix >>
 
-  fun toString (H >> (P, tau)) =
+  val conclToString =
+    fn TRUE (P, tau) => DebugShowAbt.toString P ^ " true"
+     | TYPE (P, tau) => DebugShowAbt.toString P ^ " type"
+
+  fun toString (H >> concl) =
     SymbolTelescope.toString (fn (m, tau) => DebugShowAbt.toString m) (#hypctx H)
       ^ " >> "
-      ^ DebugShowAbt.toString P
+      ^ conclToString concl
 end

--- a/src/syntax/sequent.sml
+++ b/src/syntax/sequent.sml
@@ -24,11 +24,26 @@ struct
   infix >>
 
   val conclToString =
-    fn TRUE (P, tau) => DebugShowAbt.toString P ^ " true"
-     | TYPE (P, tau) => DebugShowAbt.toString P ^ " type"
+    fn TRUE (P, tau) => ShowAbt.toString P ^ " true"
+     | TYPE (P, tau) => ShowAbt.toString P ^ " type"
+
+  fun hypothesesToString H =
+    let
+      open SymbolTelescope open ConsView
+      val rec go =
+        fn Empty => ""
+         | Cons (x, (a, tau), tl) =>
+             let
+               val hyp = Symbol.toString x ^ " : " ^ ShowAbt.toString a
+             in
+               hyp ^ "\n" ^ go (out tl)
+             end
+    in
+      go (out H)
+    end
 
   fun toString (H >> concl) =
-    SymbolTelescope.toString (fn (m, tau) => DebugShowAbt.toString m) (#hypctx H)
-      ^ " >> "
+    hypothesesToString (#hypctx H)
+      ^ "\226\138\162 "
       ^ conclToString concl
 end

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -72,19 +72,10 @@ Def speciesExample : exp = [
   { x : Base{exp} | ~{exp}(x; Base{triv}) }
 ].
 
+Tac try(t : tac) = [
+  {t} || {id}
+].
+
 Thm speciesTest : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })] : triv by [
-  eval-goal;
-  x:triv <- eq;
-  // note how a universe level did not need to be supplied to the
-  // [eq] tactic; instead, a subgoal for a universe level is generated,
-  // and it is propagated to the following type-functionality subgoal using
-  // Dependent LCF.
-  [ eq
-  , intro
-  , intro;
-    [ witness{lvl} lbase; eval-goal; eq
-    , eval-goal; eq
-    ]
-  ];
-  crefl
+  repeat(auto)
 ].

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -72,7 +72,7 @@ Def speciesExample : exp = [
   { x : Base{exp} | ~{exp}(x; Base{triv}) }
 ].
 
-Thm speciesTest[i : lvl] : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })] : triv by [
+Thm speciesTest : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })] : triv by [
   eval-goal;
   x:triv <- eq;
   // note how a universe level did not need to be supplied to the
@@ -82,7 +82,7 @@ Thm speciesTest[i : lvl] : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })
   [ eq
   , intro
   , intro;
-    [ witness{lvl} lbase[i]; eval-goal; eq
+    [ witness{lvl} lbase; eval-goal; eq
     , eval-goal; eq
     ]
   ];

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -72,7 +72,7 @@ Def speciesExample : exp = [
   { x : Base{exp} | ~{exp}(x; Base{triv}) }
 ].
 
-Thm speciesTest(i : lvl) : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })] : triv by [
+Thm speciesTest[i : lvl] : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })] : triv by [
   eval-goal;
   x:triv <- eq;
   // note how a universe level did not need to be supplied to the
@@ -81,7 +81,7 @@ Thm speciesTest(i : lvl) : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })
   // Dependent LCF.
   [ eq
   , intro
-  , witness{lvl} i; eval-goal; eq
+  , witness{lvl} lbase[i]; eval-goal; eq
   , eval-goal; eq;
     #0 {
       y:triv <- elim[x:triv];

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -79,3 +79,7 @@ Tac try(t : tac) = [
 Thm speciesTest : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })] : triv by [
   repeat(auto)
 ].
+
+Thm demo : [{x : Base{triv} | ~{triv}(x; Ax)}] : triv by [
+  repeat(auto)
+].

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -81,12 +81,10 @@ Thm speciesTest[i : lvl] : [member{triv}(Ax; {x : Base{triv} | ~{triv}(x; Ax) })
   // Dependent LCF.
   [ eq
   , intro
-  , witness{lvl} lbase[i]; eval-goal; eq
-  , eval-goal; eq;
-    #0 {
-      y:triv <- elim[x:triv];
-      hyp[y:triv]
-    }
+  , intro;
+    [ witness{lvl} lbase[i]; eval-goal; eq
+    , eval-goal; eq
+    ]
   ];
   crefl
 ].


### PR DESCRIPTION
To resolve #43, I've introduced a new form of sequent that is meant to prove that something is a type, at *some* (unspecified) level. The synthesis/evidence of the judgment is a closed level expression such that the type is a member of that universe.

This allows us to do level inference as a tactic outside the refiner, which is awesome. It is possible to imagine a similar treatment being used to enable other forms of implicit parameter (/cc @freebroccolo).